### PR TITLE
fix: exclude static assets from SPA fallback routing

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -4,16 +4,13 @@
     "exclude": [
       "/assets/*",
       "/api/*",
-      "/.auth/*"
+      "/.auth/*",
+      "*.{js,css,png,jpg,jpeg,gif,svg,ico,woff,woff2,ttf,eot,json,xml}"
     ]
   },
   "mimeTypes": {
-    ".json": "text/json"
-  },
-  "responseOverrides": {
-    "404": {
-      "rewrite": "/index.html",
-      "statusCode": 200
-    }
+    ".json": "application/json",
+    ".js": "application/javascript",
+    ".css": "text/css"
   }
 }


### PR DESCRIPTION
**Critical fix for blank page issue**

The site was showing blank because esponseOverrides was rewriting ALL 404s (including JS/CSS files) to index.html.

**Changes:**
- Removed responseOverrides that conflicted with navigationFallback
- Added explicit file extension exclusions
- Added proper MIME types for JS/CSS

**Impact:** Site will load correctly after deployment